### PR TITLE
Removed deprecated imports from graphrag_backend.py of yogasutra 

### DIFF
--- a/src/ask_yogasutra/README.md
+++ b/src/ask_yogasutra/README.md
@@ -40,9 +40,9 @@ Graph RAG is the next big thing, IKIGAI, with Sanskrit it's Specific Knowledge. 
 ## Supported Models
 
 This project uses Groq API with the following open-source models:
-- `llama3-70b-8192` (default, most capable)
-- `llama3-8b-8192` (faster, good for simple queries)
-- `mixtral-8x7b-32768` (good balance)
+- `llama-3.3-70b-versatile` (default, most capable)
+- `llama-3.1-8b-instant` (faster, good for simple queries)
+- `mistral-saba-24b` (good balance)
 
 To change the model, update `GROQ_MODEL_NAME` in the backend files.
 

--- a/src/ask_yogasutra/graphrag_backend.py
+++ b/src/ask_yogasutra/graphrag_backend.py
@@ -13,8 +13,8 @@ from llama_index.core.node_parser import SentenceSplitter
 # from llama_index.llms.llama_cpp import LlamaCPP
 from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 from llama_index.core.schema import TextNode
-from llama_index.core.response.schema import Response
-from llama_index.graph_stores.simple import SimpleGraphStore
+from llama_index.core import Response
+from llama_index.core.graph_stores import SimpleGraphStore
 from llama_index.llms.groq import Groq
 import os
 import unittest
@@ -40,7 +40,7 @@ warnings.filterwarnings("ignore", category=UserWarning)
 EMBEDDING_MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
 # LLAMA_MODEL_PATH = "llama-2-7b-chat.Q4_K_M.gguf"
 GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
-GROQ_MODEL_NAME = "llama3-70b-8192"  # or "llama3-8b-8192", "mixtral-8x7b-32768"
+GROQ_MODEL_NAME = "llama-3.1-8b-instant" #"llama-3.1-8b-instant" or "mistral-saba-24b", "llama-3.3-70b-versatile"
 
 class CitationQueryEngine:
     def __init__(self, base_query_engine):

--- a/src/ask_yogasutra/requirements.txt
+++ b/src/ask_yogasutra/requirements.txt
@@ -11,7 +11,6 @@ transformers==4.53.0
 llama-index-core==0.10.57
 llama-index-llms-groq==0.1.4
 llama-index-embeddings-huggingface==0.2.2
-llama-index-graph-stores-simple==0.2.0
 llama-cpp-python==0.2.72
 langchain==0.2.10
 psutil==5.9.8


### PR DESCRIPTION
1. Removed deprecated imports from graphrag_backend.py of yogasutra project.
3. Removed depreacted package llama-index-graph-stores-simple.
2. Updated documentation with working Groq models.